### PR TITLE
[BE] Feat: #40 게시글 작성 및 목록, 단건 조회

### DIFF
--- a/Backend/auth/src/main/java/marchtue/reuse/auth/application/client/UserClient.java
+++ b/Backend/auth/src/main/java/marchtue/reuse/auth/application/client/UserClient.java
@@ -1,7 +1,6 @@
 package marchtue.reuse.auth.application.client;
 
 
-import java.util.UUID;
 import marchtue.reuse.auth.application.dto.response.UserInfoResponse;
 
 public interface UserClient {

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClient.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClient.java
@@ -3,11 +3,13 @@ package marchtue.reuse.trade.application.client;
 
 import java.util.List;
 import java.util.UUID;
+import marchtue.reuse.trade.application.dto.response.ReadSellerResponse;
 import marchtue.reuse.trade.application.dto.response.UserSimpleInfoResponse;
 
 public interface UserClient {
 
   List<UserSimpleInfoResponse> getUserInfoList(List<UUID> userIds);
 
+  ReadSellerResponse getSellerInfo(UUID sellerId);
 }
 

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClient.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClient.java
@@ -1,0 +1,13 @@
+package marchtue.reuse.trade.application.client;
+
+
+import java.util.List;
+import java.util.UUID;
+import marchtue.reuse.trade.application.dto.response.UserSimpleInfoResponse;
+
+public interface UserClient {
+
+  List<UserSimpleInfoResponse> getUserInfoList(List<UUID> userIds);
+
+}
+

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClientImpl.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClientImpl.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import marchtue.reuse.trade.application.dto.response.ReadSellerResponse;
 import marchtue.reuse.trade.application.dto.response.UserSimpleInfoResponse;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,14 @@ public class UserClientImpl implements UserClient {
     ResponseEntity<UserSimpleInfoResponse[]> response = restTemplate.postForEntity(url, request,
         UserSimpleInfoResponse[].class);
     return Arrays.asList(Objects.requireNonNull(response.getBody()));
+  }
+
+  @Override
+  public ReadSellerResponse getSellerInfo(UUID sellerId) {
+    String url = "http://user-service:19091/internal/users/seller-info/{sellerId}";
+    ReadSellerResponse response = restTemplate.getForObject(url, ReadSellerResponse.class,
+        sellerId);
+    return response;
   }
 
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClientImpl.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/client/UserClientImpl.java
@@ -1,0 +1,32 @@
+package marchtue.reuse.trade.application.client;
+
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import marchtue.reuse.trade.application.dto.response.UserSimpleInfoResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class UserClientImpl implements UserClient {
+
+  private final RestTemplate restTemplate;
+
+  public UserClientImpl() {
+    this.restTemplate = new RestTemplate();
+  }
+
+  @Override
+  public List<UserSimpleInfoResponse> getUserInfoList(List<UUID> userIds) {
+    String url = "http://user-service:19091/internal/users/info-list";
+    HttpEntity<List<UUID>> request = new HttpEntity<>(userIds);
+    ResponseEntity<UserSimpleInfoResponse[]> response = restTemplate.postForEntity(url, request,
+        UserSimpleInfoResponse[].class);
+    return Arrays.asList(Objects.requireNonNull(response.getBody()));
+  }
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/request/CreatePostRequest.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/request/CreatePostRequest.java
@@ -1,0 +1,21 @@
+package marchtue.reuse.trade.application.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import java.util.UUID;
+import marchtue.reuse.trade.domain.enums.ProductStateEnum;
+
+public record CreatePostRequest(
+    @NotNull String title,
+    @NotNull UUID category,
+    @Min(0L) Long price,
+    @NotNull List<String> images,
+    String content,
+    boolean isDirect,
+    String directAddress,
+    boolean isParcel,
+    @NotNull ProductStateEnum productState
+) {
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/CreatePostResponse.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/CreatePostResponse.java
@@ -1,0 +1,9 @@
+package marchtue.reuse.trade.application.dto.response;
+
+import java.util.UUID;
+
+public record CreatePostResponse(
+    UUID postId
+) {
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadPostListResponse.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadPostListResponse.java
@@ -1,0 +1,40 @@
+package marchtue.reuse.trade.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import marchtue.reuse.trade.domain.enums.PostStateEnum;
+import marchtue.reuse.trade.domain.enums.ProductStateEnum;
+import marchtue.reuse.trade.domain.model.Post;
+
+public record ReadPostListResponse(
+    UUID postId,
+    String title,
+    String nickname,
+    BigDecimal rating,
+    long price,
+    LocalDateTime createdAt,
+    PostStateEnum postState,
+    ProductStateEnum productState,
+    String thumbnail,
+    boolean isFav
+) {
+
+  public static ReadPostListResponse from(Post post, String nickname, BigDecimal rating,
+      boolean isFav) {
+    String thumbnail = post.getPostImages().isEmpty() ?
+        null : post.getPostImages().get(0).getImageLink();
+
+    return new ReadPostListResponse(
+        post.getId(),
+        post.getTitle(),
+        nickname,
+        rating,
+        post.getPrice(),
+        post.getCreatedAt(),
+        post.getPostState(),
+        post.getProductState(),
+        thumbnail,
+        isFav);
+  }
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadPostResponse.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadPostResponse.java
@@ -1,0 +1,9 @@
+package marchtue.reuse.trade.application.dto.response;
+
+public record ReadPostResponse(
+
+    ReadProductResponse product,
+    ReadSellerResponse seller
+) {
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadProductResponse.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadProductResponse.java
@@ -1,0 +1,42 @@
+package marchtue.reuse.trade.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import marchtue.reuse.trade.domain.enums.PostStateEnum;
+import marchtue.reuse.trade.domain.enums.ProductStateEnum;
+import marchtue.reuse.trade.domain.model.Post;
+
+public record ReadProductResponse(
+    String title,
+    String category,
+    long price,
+    List<String> images,
+    String content,
+    boolean isDirect,
+    String directAddress,
+    boolean isParcel,
+    ProductStateEnum productState,
+    boolean isFav,
+    PostStateEnum postState,
+    LocalDateTime createdAt
+
+) {
+
+  public static ReadProductResponse from(Post post, List<String> images, boolean isFav) {
+    return new ReadProductResponse(
+        post.getTitle(),
+        post.getCategory().getName(),
+        post.getPrice(),
+        images,
+        post.getContent(),
+        post.getIsDirect(),
+        post.getDirectAddress(),
+        post.getIsParcel(),
+        post.getProductState(),
+        isFav,
+        post.getPostState(),
+        post.getCreatedAt()
+    );
+  }
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadSellerResponse.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/ReadSellerResponse.java
@@ -1,0 +1,17 @@
+package marchtue.reuse.trade.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReadSellerResponse(
+    UUID serllerId,
+    String profile,
+    String nickname,
+    LocalDateTime createdAt,
+    BigDecimal rating,
+    Long inProgressTrade,
+    Long completedTrade
+) {
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/UserSimpleInfoResponse.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/dto/response/UserSimpleInfoResponse.java
@@ -1,0 +1,12 @@
+package marchtue.reuse.trade.application.dto.response;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record UserSimpleInfoResponse(
+    UUID userId,
+    String nickname,
+    BigDecimal rating
+) {
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/CategoryService.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/CategoryService.java
@@ -21,8 +21,7 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class CategoryService {
-
-  private final JwtUtil jwtUtil;
+  
   private final CategoryRepository categoryRepository;
 
   public ApiResponse addCategory(AddCategoryRequest req) {
@@ -39,7 +38,7 @@ public class CategoryService {
 
     AddCategoryResponse response = new AddCategoryResponse(category.getId(), category.getName());
 
-    return new ApiResponse(200, "succeeded", response);
+    return ApiResponse.ok(response);
 
   }
 
@@ -51,7 +50,7 @@ public class CategoryService {
         .map(cate -> new CategoryListResponse(cate.getId(), cate.getName()))
         .toList();
 
-    return new ApiResponse(200, "succeeded", response);
+    return ApiResponse.ok(response);
   }
 
 
@@ -67,7 +66,7 @@ public class CategoryService {
     Category updatedCategory = category.update(req.name(), req.isActive());
     categoryRepository.save(updatedCategory);
 
-    return new ApiResponse(200, "succeeded", null);
+    return ApiResponse.ok();
 
   }
 
@@ -79,7 +78,7 @@ public class CategoryService {
     Category category = findById(categoryId);
     categoryRepository.delete(category);
 
-    return new ApiResponse(200, "succeeded", null);
+    return ApiResponse.ok();
 
   }
 
@@ -106,7 +105,7 @@ public class CategoryService {
     return categoryRepository.findByName(name);
   }
 
-  private Category findById(UUID id) {
+  public Category findById(UUID id) {
     return categoryRepository.findById(id)
         .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
   }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/PostService.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/PostService.java
@@ -1,17 +1,26 @@
 package marchtue.reuse.trade.application.service;
 
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import marchtue.reuse.trade.application.client.UserClient;
 import marchtue.reuse.trade.application.dto.request.CreatePostRequest;
 import marchtue.reuse.trade.application.dto.response.CreatePostResponse;
+import marchtue.reuse.trade.application.dto.response.ReadPostListResponse;
+import marchtue.reuse.trade.application.dto.response.UserSimpleInfoResponse;
 import marchtue.reuse.trade.domain.model.Category;
 import marchtue.reuse.trade.domain.model.Post;
 import marchtue.reuse.trade.domain.model.PostImage;
-import marchtue.reuse.trade.domain.repository.PostImageRepository;
+import marchtue.reuse.trade.domain.repository.FavPostRepository;
 import marchtue.reuse.trade.domain.repository.PostRepository;
 import marchtue.reuse.trade.exception.BusinessException;
 import marchtue.reuse.trade.exception.ErrorCode;
 import marchtue.reuse.trade.global.dto.ApiResponse;
+import marchtue.reuse.trade.global.util.RequestUtil;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +29,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
   private final PostRepository postRepository;
-  private final PostImageRepository postImageRepository;
+  private final FavPostRepository favPostRepository;
   private final CategoryService categoryService;
+  private final UserClient userClient;
 
   @Transactional
   public ApiResponse createPost(CreatePostRequest req) {
@@ -59,5 +69,39 @@ public class PostService {
 
     return ApiResponse.ok(res);
 
+  }
+
+  public ApiResponse readPostList(UUID categoryId) {
+    List<Post> posts = (categoryId == null)
+        ? postRepository.findAll()
+        : postRepository.findByCategory(categoryService.findById(categoryId));
+
+    // 작성자 ID 목록 수집
+    List<UUID> userIds = posts.stream()
+        .map(Post::getCreatedBy)
+        .distinct()
+        .toList();
+
+    // 사용자 정보 배치 요청
+    List<UserSimpleInfoResponse> userInfos = userClient.getUserInfoList(userIds);
+
+    // Map<UUID, UserInfoResponse> 구성
+    Map<UUID, UserSimpleInfoResponse> userInfoMap = userInfos.stream()
+        .collect(Collectors.toMap(UserSimpleInfoResponse::userId, Function.identity()));
+
+    UUID currentUserId = RequestUtil.getCurrentUserId();
+
+    // 응답 변환
+    List<ReadPostListResponse> res = posts.stream()
+        .map(post -> {
+          UserSimpleInfoResponse userInfo = userInfoMap.get(post.getCreatedBy());
+          String nickname = userInfo != null ? userInfo.nickname() : null;
+          BigDecimal rating = userInfo != null ? userInfo.rating() : null;
+          boolean isFav = favPostRepository.existsByUserIdAndPostId(currentUserId, post.getId());
+          return ReadPostListResponse.from(post, nickname, rating, isFav);
+        })
+        .toList();
+
+    return ApiResponse.ok(res);
   }
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/PostService.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/PostService.java
@@ -11,16 +11,25 @@ import marchtue.reuse.trade.application.client.UserClient;
 import marchtue.reuse.trade.application.dto.request.CreatePostRequest;
 import marchtue.reuse.trade.application.dto.response.CreatePostResponse;
 import marchtue.reuse.trade.application.dto.response.ReadPostListResponse;
+import marchtue.reuse.trade.application.dto.response.ReadPostResponse;
+import marchtue.reuse.trade.application.dto.response.ReadProductResponse;
+import marchtue.reuse.trade.application.dto.response.ReadSellerResponse;
 import marchtue.reuse.trade.application.dto.response.UserSimpleInfoResponse;
 import marchtue.reuse.trade.domain.model.Category;
 import marchtue.reuse.trade.domain.model.Post;
 import marchtue.reuse.trade.domain.model.PostImage;
 import marchtue.reuse.trade.domain.repository.FavPostRepository;
+import marchtue.reuse.trade.domain.repository.PostImageRepository;
 import marchtue.reuse.trade.domain.repository.PostRepository;
 import marchtue.reuse.trade.exception.BusinessException;
 import marchtue.reuse.trade.exception.ErrorCode;
 import marchtue.reuse.trade.global.dto.ApiResponse;
+import marchtue.reuse.trade.global.dto.PaginatedResponse;
 import marchtue.reuse.trade.global.util.RequestUtil;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +40,7 @@ public class PostService {
   private final PostRepository postRepository;
   private final FavPostRepository favPostRepository;
   private final CategoryService categoryService;
+  private final PostImageRepository postImageRepository;
   private final UserClient userClient;
 
   @Transactional
@@ -71,28 +81,26 @@ public class PostService {
 
   }
 
-  public ApiResponse readPostList(UUID categoryId) {
-    List<Post> posts = (categoryId == null)
-        ? postRepository.findAll()
-        : postRepository.findByCategory(categoryService.findById(categoryId));
+  public ApiResponse readPostList(UUID categoryId, int page, int size) {
+    Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<Post> postPage = (categoryId == null)
+        ? postRepository.findAll(pageable)
+        : postRepository.findByCategory(categoryService.findById(categoryId), pageable);
 
-    // 작성자 ID 목록 수집
+    List<Post> posts = postPage.getContent();
+
     List<UUID> userIds = posts.stream()
         .map(Post::getCreatedBy)
         .distinct()
         .toList();
 
-    // 사용자 정보 배치 요청
     List<UserSimpleInfoResponse> userInfos = userClient.getUserInfoList(userIds);
-
-    // Map<UUID, UserInfoResponse> 구성
     Map<UUID, UserSimpleInfoResponse> userInfoMap = userInfos.stream()
         .collect(Collectors.toMap(UserSimpleInfoResponse::userId, Function.identity()));
 
     UUID currentUserId = RequestUtil.getCurrentUserId();
 
-    // 응답 변환
-    List<ReadPostListResponse> res = posts.stream()
+    List<ReadPostListResponse> content = posts.stream()
         .map(post -> {
           UserSimpleInfoResponse userInfo = userInfoMap.get(post.getCreatedBy());
           String nickname = userInfo != null ? userInfo.nickname() : null;
@@ -102,6 +110,33 @@ public class PostService {
         })
         .toList();
 
+    return ApiResponse.ok(new PaginatedResponse<>(
+        postPage.getTotalElements(),
+        postPage.getTotalPages(),
+        page,
+        size,
+        content
+    ));
+  }
+
+  // 게시물 상세조회
+  public ApiResponse readPost(UUID postId) {
+    Post post = findById(postId);
+    UUID sellerId = post.getCreatedBy();
+    ReadSellerResponse sellerInfo = userClient.getSellerInfo(sellerId);
+    boolean isFav = favPostRepository.existsByUserIdAndPostId(RequestUtil.getCurrentUserId(),
+        postId);
+    List<String> images = postImageRepository.findAllByPostId(postId).stream()
+        .map(PostImage::getImageLink)
+        .toList();
+    ReadProductResponse postInfo = ReadProductResponse.from(post, images, isFav);
+    ReadPostResponse res = new ReadPostResponse(postInfo, sellerInfo);
     return ApiResponse.ok(res);
+  }
+
+
+  private Post findById(UUID postId) {
+    return postRepository.findById(postId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
   }
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/PostService.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/application/service/PostService.java
@@ -1,0 +1,63 @@
+package marchtue.reuse.trade.application.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import marchtue.reuse.trade.application.dto.request.CreatePostRequest;
+import marchtue.reuse.trade.application.dto.response.CreatePostResponse;
+import marchtue.reuse.trade.domain.model.Category;
+import marchtue.reuse.trade.domain.model.Post;
+import marchtue.reuse.trade.domain.model.PostImage;
+import marchtue.reuse.trade.domain.repository.PostImageRepository;
+import marchtue.reuse.trade.domain.repository.PostRepository;
+import marchtue.reuse.trade.exception.BusinessException;
+import marchtue.reuse.trade.exception.ErrorCode;
+import marchtue.reuse.trade.global.dto.ApiResponse;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+
+  private final PostRepository postRepository;
+  private final PostImageRepository postImageRepository;
+  private final CategoryService categoryService;
+
+  @Transactional
+  public ApiResponse createPost(CreatePostRequest req) {
+
+    if (!req.isDirect() && !req.isDirect()) {
+      throw new BusinessException(ErrorCode.TRADE_WAY_ERROR);
+    }
+    if (req.isDirect() && req.directAddress() == null) {
+      throw new BusinessException(ErrorCode.DIRECT_ADDRESS);
+    }
+    Category category = categoryService.findById(req.category());
+
+    List<PostImage> imageEntities = req.images().stream()
+        .map(link -> PostImage.builder()
+            .imageLink(link)
+            .build())
+        .toList();
+
+    Post post = Post.create(
+        req.title(),
+        req.content(),
+        req.isParcel(),
+        req.isDirect(),
+        req.directAddress(),
+        req.productState(),
+        req.price(),
+        category,
+        imageEntities
+    );
+
+    imageEntities.forEach(img -> img.setPost(post));
+    Post savedPost = postRepository.save(post);
+
+    CreatePostResponse res = new CreatePostResponse(savedPost.getId());
+
+    return ApiResponse.ok(res);
+
+  }
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/model/Post.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/model/Post.java
@@ -49,7 +49,7 @@ public class Post extends BaseEntity {
 
   private ProductStateEnum productState;
 
-  private PostStateEnum tradeState;
+  private PostStateEnum postState;
 
   private long price;
 
@@ -80,7 +80,7 @@ public class Post extends BaseEntity {
         .isDirect(isDirect)
         .directAddress(directAddress)
         .productState(productStateEnum)
-        .tradeState(PostStateEnum.IN_PROGRESS)
+        .postState(PostStateEnum.IN_PROGRESS)
         .price(price)
         .count(0L)
         .category(category)

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/model/Post.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/model/Post.java
@@ -5,6 +5,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -53,8 +55,36 @@ public class Post extends BaseEntity {
 
   private long count;
 
-  // 카테고리 Id 추가 필요
+  @ManyToOne
+  @JoinColumn(name = "category_id")
+  private Category category;
 
   @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
   private List<PostImage> postImages = new ArrayList<>();
+
+  public static Post create(
+      String title,
+      String content,
+      boolean isParcel,
+      boolean isDirect,
+      String directAddress,
+      ProductStateEnum productStateEnum,
+      long price,
+      Category category,
+      List<PostImage> postImages
+  ) {
+    return new Post().builder()
+        .title(title)
+        .content(content)
+        .isParcel(isParcel)
+        .isDirect(isDirect)
+        .directAddress(directAddress)
+        .productState(productStateEnum)
+        .tradeState(PostStateEnum.IN_PROGRESS)
+        .price(price)
+        .count(0L)
+        .category(category)
+        .postImages(postImages)
+        .build();
+  }
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/model/PostImage.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/model/PostImage.java
@@ -33,4 +33,8 @@ public class PostImage extends BaseEntityNonUpdated {
   @JoinColumn(name = "post_id")
   private Post post;
 
+
+  public void setPost(Post post) {
+    this.post = post;
+  }
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/FavPostRepository.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/FavPostRepository.java
@@ -5,4 +5,5 @@ import java.util.UUID;
 public interface FavPostRepository {
 
   boolean existsByUserIdAndPostId(UUID currentUserId, UUID id);
+
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/FavPostRepository.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/FavPostRepository.java
@@ -1,5 +1,8 @@
 package marchtue.reuse.trade.domain.repository;
 
+import java.util.UUID;
+
 public interface FavPostRepository {
 
+  boolean existsByUserIdAndPostId(UUID currentUserId, UUID id);
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostImageRepository.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostImageRepository.java
@@ -1,5 +1,10 @@
 package marchtue.reuse.trade.domain.repository;
 
+import java.util.List;
+import java.util.UUID;
+import marchtue.reuse.trade.domain.model.PostImage;
+
 public interface PostImageRepository {
 
+  List<PostImage> findAllByPostId(UUID postId);
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostRepository.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostRepository.java
@@ -1,5 +1,8 @@
 package marchtue.reuse.trade.domain.repository;
 
+import marchtue.reuse.trade.domain.model.Post;
+
 public interface PostRepository {
 
+  Post save(Post post);
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostRepository.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostRepository.java
@@ -1,14 +1,19 @@
 package marchtue.reuse.trade.domain.repository;
 
-import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import marchtue.reuse.trade.domain.model.Category;
 import marchtue.reuse.trade.domain.model.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface PostRepository {
 
   Post save(Post post);
 
-  List<Post> findAll();
+  Page<Post> findAll(Pageable pageable);
 
-  List<Post> findByCategory(Category category);
+  Page<Post> findByCategory(Category category, Pageable pageable);
+
+  Optional<Post> findById(UUID postId);
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostRepository.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/domain/repository/PostRepository.java
@@ -1,8 +1,14 @@
 package marchtue.reuse.trade.domain.repository;
 
+import java.util.List;
+import marchtue.reuse.trade.domain.model.Category;
 import marchtue.reuse.trade.domain.model.Post;
 
 public interface PostRepository {
 
   Post save(Post post);
+
+  List<Post> findAll();
+
+  List<Post> findByCategory(Category category);
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/exception/ErrorCode.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/exception/ErrorCode.java
@@ -8,8 +8,9 @@ public enum ErrorCode {
   FORBIDDEN(403, "forbidden"),
   NO_ROLE(400, "theres no role"),
   Duplicated(400, "already exist"),
-  NOT_FOUND(404, "not found");
-
+  NOT_FOUND(404, "not found"),
+  TRADE_WAY_ERROR(400, "parcel/direct error"),
+  DIRECT_ADDRESS(400, "direct address is null");
 
   private final int code;
   private final String message;

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/global/dto/ApiResponse.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/global/dto/ApiResponse.java
@@ -9,4 +9,19 @@ public record ApiResponse<T>(
     T data
 ) {
 
+  public static <T> ApiResponse<T> ok(T data) {
+    return new ApiResponse<>(200, "succeeded", data);
+  }
+
+  public static ApiResponse<Void> ok() {
+    return new ApiResponse<>(200, "succeeded", null);
+  }
+
+  public static <T> ApiResponse<T> of(int code, String msg, T data) {
+    return new ApiResponse<>(code, msg, data);
+  }
+
+  public static ApiResponse<Void> error(int code, String msg) {
+    return new ApiResponse<>(code, msg, null);
+  }
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/global/util/RequestUtil.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/global/util/RequestUtil.java
@@ -1,9 +1,8 @@
 package marchtue.reuse.trade.global.util;
 
-import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 public class RequestUtil {
 
@@ -12,15 +11,13 @@ public class RequestUtil {
   }
 
   public static UUID getCurrentUserId() {
-    ServletRequestAttributes attributes =
-        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
-    if (attributes == null) {
+    if (auth == null || !auth.isAuthenticated() || auth.getPrincipal() == null) {
       return null;
     }
 
-    HttpServletRequest req = attributes.getRequest();
-    return UUID.fromString(req.getHeader("X-User-Id"));
+    return (UUID) auth.getPrincipal();
   }
 
 

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/global/util/RestTemplateConfig.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/global/util/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package marchtue.reuse.trade.global.util;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+  @Bean
+  public RestTemplate restTemplate() {
+    return new RestTemplate();
+  }
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/infrastructure/jpa/JpaPostRepository.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/infrastructure/jpa/JpaPostRepository.java
@@ -1,0 +1,10 @@
+package marchtue.reuse.trade.infrastructure.jpa;
+
+import java.util.UUID;
+import marchtue.reuse.trade.domain.model.Post;
+import marchtue.reuse.trade.domain.repository.PostRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaPostRepository extends PostRepository, JpaRepository<Post, UUID> {
+
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/presentation/PostController.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/presentation/PostController.java
@@ -1,12 +1,15 @@
 package marchtue.reuse.trade.presentation;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import marchtue.reuse.trade.application.dto.request.CreatePostRequest;
 import marchtue.reuse.trade.application.service.PostService;
 import marchtue.reuse.trade.global.dto.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,4 +26,13 @@ public class PostController {
   ) {
     return postService.createPost(req);
   }
+
+  // 판매글 목록 조회
+  @GetMapping
+  public ApiResponse readPostList(
+      @RequestParam(required = false) UUID categoryId
+  ) {
+    return postService.readPostList(categoryId);
+  }
+
 }

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/presentation/PostController.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/presentation/PostController.java
@@ -1,0 +1,26 @@
+package marchtue.reuse.trade.presentation;
+
+import lombok.RequiredArgsConstructor;
+import marchtue.reuse.trade.application.dto.request.CreatePostRequest;
+import marchtue.reuse.trade.application.service.PostService;
+import marchtue.reuse.trade.global.dto.ApiResponse;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/be/v1/posts")
+public class PostController {
+
+  private final PostService postService;
+
+  // 판매글 등록
+  @PostMapping
+  public ApiResponse createPost(
+      @RequestBody CreatePostRequest req
+  ) {
+    return postService.createPost(req);
+  }
+}

--- a/Backend/trade/src/main/java/marchtue/reuse/trade/presentation/PostController.java
+++ b/Backend/trade/src/main/java/marchtue/reuse/trade/presentation/PostController.java
@@ -6,6 +6,7 @@ import marchtue.reuse.trade.application.dto.request.CreatePostRequest;
 import marchtue.reuse.trade.application.service.PostService;
 import marchtue.reuse.trade.global.dto.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,9 +31,18 @@ public class PostController {
   // 판매글 목록 조회
   @GetMapping
   public ApiResponse readPostList(
-      @RequestParam(required = false) UUID categoryId
+      @RequestParam(required = false) UUID categoryId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size
   ) {
-    return postService.readPostList(categoryId);
+    return postService.readPostList(categoryId, page, size);
   }
 
+  // 판매글 상세조회
+  @GetMapping("/{postId}")
+  public ApiResponse readPost(
+      @PathVariable UUID postId
+  ) {
+    return postService.readPost(postId);
+  }
 }

--- a/Backend/user/src/main/java/marchtue/reuse/user/application/dto/response/ReadSellerResponse.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/application/dto/response/ReadSellerResponse.java
@@ -1,0 +1,30 @@
+package marchtue.reuse.user.application.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import marchtue.reuse.user.domain.model.User;
+import marchtue.reuse.user.domain.model.UserRating;
+
+public record ReadSellerResponse(
+    UUID serllerId,
+    String profile,
+    String nickname,
+    LocalDateTime createdAt,
+    BigDecimal rating,
+    Long inProgressTrade,
+    Long completedTrade
+) {
+
+  public static ReadSellerResponse from(User user, UserRating userRating) {
+    return new ReadSellerResponse(
+        user.getId(),
+        user.getProfileImage(),
+        user.getNickname(),
+        user.getCreatedAt(),
+        userRating.getRateScore(),
+        userRating.getInProgressTrade(),
+        userRating.getCompletedTrade()
+    );
+  }
+}

--- a/Backend/user/src/main/java/marchtue/reuse/user/application/dto/response/UserSimpleInfoResponse.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/application/dto/response/UserSimpleInfoResponse.java
@@ -1,0 +1,12 @@
+package marchtue.reuse.user.application.dto.response;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record UserSimpleInfoResponse(
+    UUID userId,
+    String nickname,
+    BigDecimal rating
+) {
+
+}

--- a/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserRatingService.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserRatingService.java
@@ -1,0 +1,18 @@
+package marchtue.reuse.user.application.service;
+
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import marchtue.reuse.user.domain.model.UserRating;
+import marchtue.reuse.user.domain.repository.UserRatingRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserRatingService {
+
+  private final UserRatingRepository userRatingRepository;
+
+  public UserRating findByUserId(UUID userId) {
+    return userRatingRepository.findByUserId(userId);
+  }
+}

--- a/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserService.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserService.java
@@ -57,7 +57,7 @@ public class UserService {
       throw new BusinessException(ErrorCode.DUPLICATED_NICKNAME);
     }
 
-    return new ApiResponse(200, "succeeded", null);
+    return ApiResponse.ok();
 
   }
 
@@ -78,7 +78,7 @@ public class UserService {
 
     // 없다면 회원가입 추가정보 요청 응답
     if (user == null) {
-      return new ApiResponse(404, "user not found", "");
+      return ApiResponse.error(404, "user not found");
     }
     return null;
   }
@@ -125,7 +125,7 @@ public class UserService {
 
     Map<String, UUID> response = Map.of("user_id", savedUser.getId());
 
-    return new ApiResponse(200, "succeeded", response);
+    return ApiResponse.ok(response);
 
   }
 
@@ -160,7 +160,7 @@ public class UserService {
         user.getAccount(),
         user.getPhoneNumber()
     );
-    return new ApiResponse(200, "succceded", res);
+    return ApiResponse.ok(res);
   }
 
   public ApiResponse favCategory(UUID categoryId) {
@@ -174,7 +174,7 @@ public class UserService {
       userCategoryRepository.delete(category);
     }
 
-    return new ApiResponse(200, "succeeded", null);
+    return ApiResponse.ok();
   }
 
   private User findByNickname(String nickname) {

--- a/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserService.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserService.java
@@ -1,13 +1,16 @@
 package marchtue.reuse.user.application.service;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import marchtue.reuse.user.application.dto.request.CheckUserRequest;
 import marchtue.reuse.user.application.dto.request.NicknameCheckRequest;
 import marchtue.reuse.user.application.dto.request.UserAddInfoRequest;
 import marchtue.reuse.user.application.dto.response.MypageResponse;
+import marchtue.reuse.user.application.dto.response.UserSimpleInfoResponse;
 import marchtue.reuse.user.domain.enums.UserRoleEnum;
 import marchtue.reuse.user.domain.model.Credential;
 import marchtue.reuse.user.domain.model.User;
@@ -176,6 +179,19 @@ public class UserService {
 
     return ApiResponse.ok();
   }
+
+  public List<UserSimpleInfoResponse> getUserSimpleInfoList(List<UUID> userIds) {
+    return userIds.stream()
+        .map(userRepository::findById)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(user -> new UserSimpleInfoResponse(
+            user.getId(),
+            user.getNickname(),
+            user.getUserRating().getRateScore()))
+        .toList();
+  }
+
 
   private User findByNickname(String nickname) {
     return userRepository.findByNickname(nickname.toLowerCase());

--- a/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserService.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/application/service/UserService.java
@@ -10,6 +10,7 @@ import marchtue.reuse.user.application.dto.request.CheckUserRequest;
 import marchtue.reuse.user.application.dto.request.NicknameCheckRequest;
 import marchtue.reuse.user.application.dto.request.UserAddInfoRequest;
 import marchtue.reuse.user.application.dto.response.MypageResponse;
+import marchtue.reuse.user.application.dto.response.ReadSellerResponse;
 import marchtue.reuse.user.application.dto.response.UserSimpleInfoResponse;
 import marchtue.reuse.user.domain.enums.UserRoleEnum;
 import marchtue.reuse.user.domain.model.Credential;
@@ -25,7 +26,6 @@ import marchtue.reuse.user.domain.repository.WalletRepository;
 import marchtue.reuse.user.exception.BusinessException;
 import marchtue.reuse.user.exception.ErrorCode;
 import marchtue.reuse.user.global.dto.ApiResponse;
-import marchtue.reuse.user.global.util.JwtUtil;
 import marchtue.reuse.user.global.util.NicknameFilter;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -41,7 +41,7 @@ public class UserService {
   private final WalletRepository walletRepository;
   private final UserRatingRepository userRatingRepository;
   private final UserCategoryRepository userCategoryRepository;
-  private final JwtUtil jwtUtil;
+  private final UserRatingService userRatingService;
 
   public ApiResponse checkNickname(NicknameCheckRequest req) {
     String nickname = req.nickname();
@@ -192,6 +192,12 @@ public class UserService {
         .toList();
   }
 
+  public ReadSellerResponse getSellerInfo(UUID sellerId) {
+    User user = findById(sellerId);
+    UserRating userRating = userRatingService.findByUserId(sellerId);
+    return ReadSellerResponse.from(user, userRating);
+  }
+
 
   private User findByNickname(String nickname) {
     return userRepository.findByNickname(nickname.toLowerCase());
@@ -227,6 +233,5 @@ public class UserService {
         .map(authority -> UserRoleEnum.valueOf(authority.getAuthority()))
         .orElseThrow(() -> new BusinessException(ErrorCode.NO_ROLE));
   }
-
 
 }

--- a/Backend/user/src/main/java/marchtue/reuse/user/global/dto/ApiResponse.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/global/dto/ApiResponse.java
@@ -9,4 +9,19 @@ public record ApiResponse<T>(
     T data
 ) {
 
+  public static <T> ApiResponse<T> ok(T data) {
+    return new ApiResponse<>(200, "succeeded", data);
+  }
+
+  public static ApiResponse<Void> ok() {
+    return new ApiResponse<>(200, "succeeded", null);
+  }
+
+  public static <T> ApiResponse<T> of(int code, String msg, T data) {
+    return new ApiResponse<>(code, msg, data);
+  }
+
+  public static ApiResponse<Void> error(int code, String msg) {
+    return new ApiResponse<>(code, msg, null);
+  }
 }

--- a/Backend/user/src/main/java/marchtue/reuse/user/infrastructure/security/SecurityConfig.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/infrastructure/security/SecurityConfig.java
@@ -20,10 +20,10 @@ public class SecurityConfig {
     http
         .csrf(csrf -> csrf.disable())
         .authorizeHttpRequests(user -> user
-            .requestMatchers("internal/users/**").permitAll()
-            .requestMatchers("api/be/v1/users/check-user").permitAll()
-            .requestMatchers("api/be/v1/users/check-nickname").permitAll()
-            .requestMatchers("api/be/v1/users/register").permitAll()
+            .requestMatchers("/internal/users/**").permitAll()
+            .requestMatchers("/api/be/v1/users/check-user").permitAll()
+            .requestMatchers("/api/be/v1/users/check-nickname").permitAll()
+            .requestMatchers("/api/be/v1/users/register").permitAll()
             .anyRequest().authenticated()
         )
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/Backend/user/src/main/java/marchtue/reuse/user/presentation/UserInternalController.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/presentation/UserInternalController.java
@@ -1,10 +1,13 @@
 package marchtue.reuse.user.presentation;
 
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import marchtue.reuse.user.application.dto.request.DidCheckRequest;
 import marchtue.reuse.user.application.dto.request.UserInfoRequest;
 import marchtue.reuse.user.application.dto.response.UserInfoResponse;
+import marchtue.reuse.user.application.dto.response.UserSimpleInfoResponse;
 import marchtue.reuse.user.application.service.UserService;
 import marchtue.reuse.user.domain.model.User;
 import org.springframework.http.ResponseEntity;
@@ -40,6 +43,11 @@ public class UserInternalController {
   public ResponseEntity<Void> CheckDid(@RequestBody DidCheckRequest req) {
     userService.checkDid(req.userId(), req.did());
     return ResponseEntity.ok().build();
+  }
+
+  @PostMapping("/info-list")
+  public List<UserSimpleInfoResponse> getUserSimpleInfoList(@RequestBody List<UUID> userIds) {
+    return userService.getUserSimpleInfoList(userIds);
   }
 
 }

--- a/Backend/user/src/main/java/marchtue/reuse/user/presentation/UserInternalController.java
+++ b/Backend/user/src/main/java/marchtue/reuse/user/presentation/UserInternalController.java
@@ -6,11 +6,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import marchtue.reuse.user.application.dto.request.DidCheckRequest;
 import marchtue.reuse.user.application.dto.request.UserInfoRequest;
+import marchtue.reuse.user.application.dto.response.ReadSellerResponse;
 import marchtue.reuse.user.application.dto.response.UserInfoResponse;
 import marchtue.reuse.user.application.dto.response.UserSimpleInfoResponse;
 import marchtue.reuse.user.application.service.UserService;
 import marchtue.reuse.user.domain.model.User;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -48,6 +51,13 @@ public class UserInternalController {
   @PostMapping("/info-list")
   public List<UserSimpleInfoResponse> getUserSimpleInfoList(@RequestBody List<UUID> userIds) {
     return userService.getUserSimpleInfoList(userIds);
+  }
+
+  @GetMapping("/seller-info/{sellerId}")
+  public ReadSellerResponse getSellerInfo(
+      @PathVariable UUID sellerId
+  ) {
+    return userService.getSellerInfo(sellerId);
   }
 
 }


### PR DESCRIPTION
# [BE] Feat: #40 게시글 작성 및 목록, 단건 조회

## 개요

게시글 작성 및 목록, 단건 조회

## 변경 사항

- 게시글 작성 구현
- RequestUtil 수정
- ErrorCode 추가
- ApiResponse 수정(반복코드 리팩토링)
- 게시글 목록 조회 구현
- 게시글 상세 조회(일반 사용자)

## 스크린샷 (선택사항)

<!-- UI 변경사항을 보여주는 스크린샷 -->

## 특이 사항

- 게시글 상세 조회(판매자)는 추후 거래 신청 및 수락 구현 후 추가하겠음.
issue: #40

<!-- 리뷰어가 알아야 할 사항이나 특별히 주의해야 할 점 -->
