### PR TITLE
[BC]Feat #69: Cash Contract 

### DIFF
--- a/BlockChain/contracts/Cash.sol
+++ b/BlockChain/contracts/Cash.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./MyToken.sol"; // ERC20 RU 토큰
+import "@openzeppelin/contracts/access/AccessControl.sol";
+
+contract Cash is AccessControl {
+    bytes32 public constant CASH_ADMIN_ROLE = keccak256("CASH_ADMIN_ROLE");
+    MyToken public immutable ruToken;
+
+    // 이벤트 정의
+    event CashCharged(
+        address indexed user,
+        uint256 amount,
+        string externalTxId
+    );
+    event CashWithdrawn(
+        address indexed user,
+        uint256 amount,
+        string externalTxId
+    );
+
+    constructor(address _ruToken) {
+        require(_ruToken != address(0), "Invalid RU Token Address");
+        ruToken = MyToken(_ruToken);
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(CASH_ADMIN_ROLE, msg.sender);
+    }
+
+    /**
+     * @dev 사용자의 Ru 충전
+     * @param user 충전 대상
+     * @param amount 충전 금액
+     * @param externalTxId 백엔드 결제 트랜잭션 ID - 외부 결제(페이먼츠, 에스크로)
+     */
+    function chargeRU(
+        address user,
+        uint256 amount,
+        string calldata externalTxId
+    ) external onlyRole(CASH_ADMIN_ROLE) {
+        require(user != address(0), "Invalid user address");
+        require(amount > 0, "Amount must be > 0");
+
+        ruToken.mint(user, amount);
+        emit CashCharged(user, amount, externalTxId);
+    }
+
+    /**
+     * @dev 사용자의 Ru 출금
+     * @param user 출금 대상
+     * @param amount 출금 금액
+     * @param externalTxId 오프체인 출금 트랜잭션
+     */
+    function withdrawRU(
+        address user,
+        uint256 amount,
+        string calldata externalTxId
+    ) external onlyRole(CASH_ADMIN_ROLE) {
+        require(user != address(0), "Invalid user address");
+        require(amount > 0, "Amount must be > 0");
+        require(ruToken.balanceOf(user) >= amount, "Insufficient balance");
+
+        ruToken.burnFrom(user, amount); // RU 소각
+        emit CashWithdrawn(user, amount, externalTxId);
+    }
+
+    /**
+     * @dev 관리자 역할 추가
+     */
+    function addCashAdmin(
+        address account
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(account != address(0), "Invalid account");
+        grantRole(CASH_ADMIN_ROLE, account);
+    }
+}

--- a/BlockChain/contracts/MyToken.sol
+++ b/BlockChain/contracts/MyToken.sol
@@ -69,6 +69,20 @@ contract MyToken is ERC20, AccessControl, ERC20Permit {
         emit Burned(msg.sender, amount);
     }
 
+    function burnFrom(
+        address user,
+        uint256 amount
+    ) public onlyRole(ADMIN_ROLE) {
+        require(user != address(0), "Invalid user address");
+        require(
+            balanceOf(user) >= amount,
+            "ERC20: Burn amount exceeds balance"
+        );
+
+        _burn(user, amount);
+        emit Burned(user, amount);
+    }
+
     function addAdmin(address account) public onlyOwner {
         require(account != address(0), "ERC20: add admin to the zero address");
         grantRole(ADMIN_ROLE, account);

--- a/BlockChain/ignition/modules/0914TotalDep.ts
+++ b/BlockChain/ignition/modules/0914TotalDep.ts
@@ -1,0 +1,25 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules';
+import * as dotenv from 'dotenv';
+import MyTokenV1 from './MyToken.v1';
+
+dotenv.config();
+
+export default buildModule("TotalModule", (m) => {
+  const { myToken } = m.useModule(MyTokenV1);
+
+  const autoReleaseDelay: number = 60 * 60 * 24 * 3; // 3일
+  const escrow = m.contract("Escrow", [autoReleaseDelay]);
+  const cash = m.contract("Cash", [myToken]);
+
+  const oracleAccountAddress: string =
+    process.env.ORACLE_ACCOUNT_ADDRESS || "0x70997970C51812dc3A010C7d01b50e0d17dc79C8";
+
+  m.call(cash, "addCashAdmin", [oracleAccountAddress]);
+  m.call(myToken, "addAdmin", [cash]);
+  console.log("Cash Deploy Ignition Deployment (Production Ready):", cash);
+
+  m.call(escrow, "grantOracleRole", [oracleAccountAddress]);
+  console.log("Escrow Deploy Ignition Deployment (Production Ready):", escrow);
+
+  return { myToken, escrow, cash };
+});

--- a/BlockChain/test/cash/cash.test.ts
+++ b/BlockChain/test/cash/cash.test.ts
@@ -1,0 +1,105 @@
+import { expect } from "chai";
+import hre from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+
+describe("Cash Contract", function () {
+  async function deployCashFixture() {
+    const [owner, user, addr2] = await hre.ethers.getSigners();
+
+    // MyToken 배포
+    const MyTokenFactory = await hre.ethers.getContractFactory("MyToken");
+    const initialSupply = 1000;
+    const myToken = await MyTokenFactory.deploy("RU Token", "RU", initialSupply);
+    await myToken.waitForDeployment();
+
+    //  Cash 배포
+    const CashFactory = await hre.ethers.getContractFactory("Cash");
+    const cash = await CashFactory.deploy(myToken.getAddress());
+    await cash.waitForDeployment();
+    await myToken.addAdmin(cash.getAddress());
+    // Cash에 owner를 관리자 추가
+    await cash.addCashAdmin(owner.address);
+
+    return { myToken, cash, owner, user, addr2 };
+  }
+
+  // 배포  테스트
+  describe("Deployment", function () {
+    it("Should set correct MyToken address in Cash", async function () {
+      const { cash, myToken } = await loadFixture(deployCashFixture);
+      expect(await cash.ruToken()).to.equal(await myToken.getAddress());
+    });
+  });
+
+  // 충전 / 출금
+  describe("Charge and Withdraw", function () {
+    it("Should charge RU correctly and emit CashCharged event", async function () {
+      const { cash, myToken, user, owner } = await loadFixture(deployCashFixture);
+      const amount = 100;
+
+      const tx = await cash.chargeRU(user.address, amount, "tx-123");
+      await tx.wait();
+
+      // 잔액 확인
+      expect(await myToken.balanceOf(user.address)).to.equal(amount);
+
+      // 이벤트 확인
+      await expect(tx)
+        .to.emit(cash, "CashCharged")
+        .withArgs(user.address, amount, "tx-123");
+    });
+
+    it("Should withdraw RU correctly and emit CashWithdrawn event", async function () {
+      const { cash, myToken, user, owner } = await loadFixture(deployCashFixture);
+      const amount = 50;
+
+      // 충전
+      await cash.chargeRU(user.address, amount, "tx-123");
+
+      // 출금
+      const tx = await cash.withdrawRU(user.address, amount, "tx-456");
+      await tx.wait();
+
+      // 잔액 확인
+      expect(await myToken.balanceOf(user.address)).to.equal(0);
+
+      // 이벤트 확인
+      await expect(tx)
+        .to.emit(cash, "CashWithdrawn")
+        .withArgs(user.address, amount, "tx-456");
+    });
+
+    it("Should revert if non-admin tries to charge", async function () {
+      const { cash, user } = await loadFixture(deployCashFixture);
+      const amount = 10;
+
+      await expect(
+        cash.connect(user).chargeRU(user.address, amount, "tx-999")
+      ).to.be.revertedWithCustomError(cash, "AccessControlUnauthorizedAccount");
+    });
+
+    it("Should revert if non-admin tries to withdraw", async function () {
+      const { cash, user } = await loadFixture(deployCashFixture);
+      const amount = 10;
+
+      await expect(
+        cash.connect(user).withdrawRU(user.address, amount, "tx-999")
+      ).to.be.revertedWithCustomError(cash, "AccessControlUnauthorizedAccount");
+    });
+  });
+
+  // 관리자 역할 테스트
+  describe("Admin management", function () {
+    it("Should allow owner to add new admin", async function () {
+      const { cash, owner, addr2 } = await loadFixture(deployCashFixture);
+
+      await cash.addCashAdmin(addr2.address);
+
+      // addr2가 관리자 권한으로 충전 가능해야 함
+      const tx = await cash.connect(addr2).chargeRU(addr2.address, 10, "tx-admin");
+      await expect(tx)
+        .to.emit(cash, "CashCharged")
+        .withArgs(addr2.address, 10, "tx-admin");
+    });
+  });
+});


### PR DESCRIPTION
# #69 Cash Contract 구현

## 개요

<!-- PR이 해결하려는 문제에 대한 간단한 설명 -->
The `Cash.sol` smart contract has been implemented to manage the charging and withdrawing of RU tokens, which are the project's ERC20 tokens. To enable this, the `burnFrom` function was added to the `MyToken.sol` contract, allowing an administrator (in this case, the `Cash` contract) to burn a specified amount of tokens from a user's address.

Additionally, the `0914TotalDep.ts` deployment module was created using Hardhat Ignition. This module orchestrates the deployment of the `MyToken`, `Escrow`, and `Cash` contracts in a correct and consistent order, ensuring that the necessary administrator roles are assigned between them.


## 변경 사항

<!-- 구현한 기능 또는 수정한 부분 목록 -->
The solution is based on the access control pattern.
1.  **`MyToken`**: A new `burnFrom` function was added. This function allows an address with the `ADMIN_ROLE` to burn tokens from another address.
2.  **`Cash`**: The `Cash` contract was implemented with two key functions:
    * `chargeRU`: Uses `ruToken.mint()` to charge tokens to a user's address. It can only be executed by an address with the `CASH_ADMIN_ROLE`.
    * `withdrawRU`: Calls `ruToken.burnFrom()` to burn tokens from a user's address. Like `chargeRU`, it requires the `CASH_ADMIN_ROLE`.
3.  **`TotalModule`**: This deployment module, powered by **Hardhat Ignition**, ensures that after `MyToken` and `Cash` are deployed, the `Cash` contract is granted the `ADMIN_ROLE` on the `MyToken` contract. This gives `Cash` the necessary permission to call the `burnFrom` function.



## 스크린샷 (선택사항)
Test Result

<img width="765" height="234" alt="image" src="https://github.com/user-attachments/assets/b6a52c84-2631-49df-bfb3-139a11b5dc15" />

<img width="1120" height="307" alt="image" src="https://github.com/user-attachments/assets/2db710f7-ebcb-4b1e-b530-ec1ef0a09529" />

## 특이 사항

<!-- 리뷰어가 알아야 할 사항이나 특별히 주의해야 할 점 -->
-   **Access Control**: The use of `AccessControl` and `onlyRole` ensures a secure system. The `CASH_ADMIN_ROLE` should be assigned to the off-chain oracle or backend service responsible for handling payment gateways.
-   **Hardhat Ignition**: This new deployment system ensures that dependencies, like granting the `ADMIN_ROLE` to the `Cash` contract, are handled automatically and reliably during deployment.
-   **Test Coverage**: The provided test results show that the new functionality is fully covered by tests, ensuring its correctness and reliability.